### PR TITLE
Fix encryption & decryption key

### DIFF
--- a/Encryptor/encryptor.lpr
+++ b/Encryptor/encryptor.lpr
@@ -107,7 +107,7 @@ var
   begin
   vStrm := TFileStream.Create(output,fmCreate);
 
-  key :='zuxiamhere';  // encryption + decryption key
+  key :='zuxiamhera';  // encryption + decryption key
 
   s1 := Tstringstream.Create('');
   writeln('[+] Encrypting the binary ...');


### PR DESCRIPTION
In agressor.lpr you use the key `$7a,$75,$78,$69,$61,$6d,$68,$65,$72,$61` which is `zuxiamhera` and NOT `zuxiamhere`.
Either change the last byte of the key to $65, or change the key inside the encryptor to zuxiamhera.